### PR TITLE
Fixed no-output because of failure to register rules

### DIFF
--- a/rdfvizler-core/src/main/java/osl/rdfvizler/dot/RDF2DotParser.java
+++ b/rdfvizler-core/src/main/java/osl/rdfvizler/dot/RDF2DotParser.java
@@ -9,11 +9,16 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 
+import osl.rdfvizler.dot.rules.RuleRegistrar;
 import osl.util.Strings;
 import osl.util.rdf.Models;
 import osl.util.rdf.vocab.DotVocabulary;
 
 public class RDF2DotParser {
+
+    static {
+        RuleRegistrar.registerRules();
+    }
 
     private static final String STRICT = "strict ";
     private static final String GRAPH = "graph ";

--- a/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
+++ b/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
@@ -3,8 +3,7 @@ package osl.rdfvizler.dot.rules;
 import org.apache.jena.reasoner.rulesys.BuiltinRegistry;
 
 public class RuleRegistrar {
-    
-    static {
+    public static void registerRules() {
         BuiltinRegistry.theRegistry.register(new ShortValue());
         BuiltinRegistry.theRegistry.register(new Namespace());
         BuiltinRegistry.theRegistry.register(new TypedValue());

--- a/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
+++ b/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
@@ -1,15 +1,21 @@
 package osl.rdfvizler.dot.rules;
 
+import org.apache.jena.reasoner.rulesys.Builtin;
 import org.apache.jena.reasoner.rulesys.BuiltinRegistry;
 
 public class RuleRegistrar {
+	
     public static void registerRules() {
-        BuiltinRegistry.theRegistry.register(new ShortValue());
-        BuiltinRegistry.theRegistry.register(new Namespace());
-        BuiltinRegistry.theRegistry.register(new TypedValue());
-        BuiltinRegistry.theRegistry.register(new BeginsWith());
-        BuiltinRegistry.theRegistry.register(new Linewrap());
-        BuiltinRegistry.theRegistry.register(new ExcludeType());
-        BuiltinRegistry.theRegistry.register(new CreateUniqueIfLit());
+        register(new ShortValue());
+        register(new Namespace());
+        register(new TypedValue());
+        register(new BeginsWith());
+        register(new Linewrap());
+        register(new ExcludeType());
+        register(new CreateUniqueIfLit());
+    }
+    
+    public static void register(Builtin rule) {
+        BuiltinRegistry.theRegistry.register(rule);
     }
 }

--- a/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
+++ b/rdfvizler-core/src/main/java/osl/rdfvizler/dot/rules/RuleRegistrar.java
@@ -4,7 +4,7 @@ import org.apache.jena.reasoner.rulesys.Builtin;
 import org.apache.jena.reasoner.rulesys.BuiltinRegistry;
 
 public class RuleRegistrar {
-	
+
     public static void registerRules() {
         register(new ShortValue());
         register(new Namespace());

--- a/rdfvizler-core/src/main/java/osl/util/rdf/Models.java
+++ b/rdfvizler-core/src/main/java/osl/util/rdf/Models.java
@@ -15,10 +15,15 @@ import org.apache.jena.util.FileManager;
 import org.apache.jena.util.FileUtils;
 import org.apache.jena.vocabulary.RDF;
 
+import osl.rdfvizler.dot.rules.RuleRegistrar;
 import osl.util.Arrays;
 import osl.util.Strings;
 
 public abstract class Models {
+
+    static {
+        RuleRegistrar.registerRules();
+    }
 
     public static final List<String> RDF_FORMATS = Arrays.toUnmodifiableList("TTL", "RDF/XML", "N3", "N-TRIPLES");
     public static final String DEFAULT_RDF_FORMAT = "TTL";

--- a/rdfvizler-core/src/main/java/osl/util/rdf/Models.java
+++ b/rdfvizler-core/src/main/java/osl/util/rdf/Models.java
@@ -15,15 +15,10 @@ import org.apache.jena.util.FileManager;
 import org.apache.jena.util.FileUtils;
 import org.apache.jena.vocabulary.RDF;
 
-import osl.rdfvizler.dot.rules.RuleRegistrar;
 import osl.util.Arrays;
 import osl.util.Strings;
 
 public abstract class Models {
-
-    static {
-        RuleRegistrar.registerRules();
-    }
 
     public static final List<String> RDF_FORMATS = Arrays.toUnmodifiableList("TTL", "RDF/XML", "N3", "N-TRIPLES");
     public static final String DEFAULT_RDF_FORMAT = "TTL";

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,15 +25,23 @@ public class DotTest {
     private final String simpleRdf = "simple_rdf.ttl";
 
 
+    /**
+     * Attempts to create the dot output for a simple RDF file applying
+     * the default rules. This should produce a DOT graph with nodes and edges
+     * This is tested by counting the number of polygons in the svg produced.
+     * This should be more than 1, as there is always one polygon in an empty svg
+     *
+     * TODO: This test should instead check if anything is drawn
+     * @throws IOException
+     */
     @Test
     public void shouldProduceNonEmptyGraph() throws IOException {
         RDFVizler rdfvizler = new RDFVizler(simpleRdf);
-        String out = rdfvizler.writeDotTextOutput();
-        int lines = out.split("\r\n|\r|\n").length;
-        assertTrue(lines > 5);
+        String out = rdfvizler.writeOutput("svg");
+        int numberOfPolygons = StringUtils.countMatches(out, "polygon");
+        assertTrue(numberOfPolygons > 1);
     }
 
-  
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -14,11 +14,22 @@ import osl.rdfvizler.ui.RDFVizler;
 import osl.util.Arrays;
 import osl.util.rdf.Models;
 
+import static org.junit.Assert.assertTrue;
+
 public class DotTest {
 
     private final boolean stdout = true; // print files also to stdout?
     
     private final String file1 = "test1.ttl";
+    private final String simpleRdf = "simple_rdf.ttl";
+
+    @Test
+    public void nonEmptyRdfShouldProduceNonEmptyGraph() throws IOException {
+        RDFVizler rdfvizler = new RDFVizler(simpleRdf);
+        String out = rdfvizler.writeDotTextOutput();
+        int lines = out.split("\r\n|\r|\n").length;
+        assertTrue(lines > 5);
+    }
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -23,14 +23,16 @@ public class DotTest {
     private final String file1 = "test1.ttl";
     private final String simpleRdf = "simple_rdf.ttl";
 
+
     @Test
-    public void nonEmptyRdfShouldProduceNonEmptyGraph() throws IOException {
+    public void shouldProduceNonEmptyGraph() throws IOException {
         RDFVizler rdfvizler = new RDFVizler(simpleRdf);
         String out = rdfvizler.writeDotTextOutput();
         int lines = out.split("\r\n|\r|\n").length;
         assertTrue(lines > 5);
     }
 
+  
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -14,14 +14,13 @@ import org.junit.rules.TemporaryFolder;
 
 import osl.rdfvizler.ui.RDFVizler;
 
-import osl.util.Arrays;
 import osl.util.rdf.Models;
 
 
 
 public class DotTest {
 
-    private final boolean stdout = true; // print files also to stdout?
+    private final boolean stdout = false; // print files also to stdout?
     
     private final String file1 = "test1.ttl";
     private final String simpleRdf = "simple_rdf.ttl";

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -1,5 +1,7 @@
 package osl.rdfvizler.dot;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -15,7 +17,7 @@ import osl.rdfvizler.ui.RDFVizler;
 import osl.util.Arrays;
 import osl.util.rdf.Models;
 
-import static org.junit.Assert.assertTrue;
+
 
 public class DotTest {
 
@@ -29,10 +31,9 @@ public class DotTest {
      * Attempts to create the dot output for a simple RDF file applying
      * the default rules. This should produce a DOT graph with nodes and edges
      * This is tested by counting the number of polygons in the svg produced.
-     * This should be more than 1, as there is always one polygon in an empty svg
-     *
+     * This should be more than 1, as there is always one polygon in an empty svg     *
      * TODO: This test should instead check if anything is drawn
-     * @throws IOException
+     * @throws IOException Exception thrown when file is not found
      */
     @Test
     public void shouldProduceNonEmptyGraph() throws IOException {

--- a/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
+++ b/rdfvizler-core/src/test/java/osl/rdfvizler/dot/DotTest.java
@@ -32,7 +32,7 @@ public class DotTest {
      * the default rules. This should produce a DOT graph with nodes and edges
      * This is tested by counting the number of polygons in the svg produced.
      * This should be more than 1, as there is always one polygon in an empty svg     *
-     * TODO: This test should instead check if anything is drawn
+     *
      * @throws IOException Exception thrown when file is not found
      */
     @Test

--- a/rdfvizler-core/src/test/resources/simple_rdf.ttl
+++ b/rdfvizler-core/src/test/resources/simple_rdf.ttl
@@ -1,0 +1,4 @@
+@prefix e:  <http://example.com/> .
+
+
+e:x e:p "Some Literal" .


### PR DESCRIPTION
The registering of the custom rules is now done in RDF2DotParser. It is slightly misplaced here, as the rules apply to Jena rule inferencing, and not dot-parsing. A better place would perhaps be Models, but that is outside the rdfvizler package, so that perhaps makes even less sense. 